### PR TITLE
run-service-simple: use released image in the simple app instructions

### DIFF
--- a/cloudbuild-simple.yaml
+++ b/cloudbuild-simple.yaml
@@ -24,28 +24,14 @@ steps:
     waitFor:
       - BUILD_SAMPLE_APP
 
-  - name: "gcr.io/cloud-builders/docker"
-    args: ["build", "-t", "${_IMAGE_COLLECTOR}", "."]
-    id: BUILD_COLLECTOR
-    waitFor: ["-"]
-
-  - name: "gcr.io/cloud-builders/docker"
-    args: ["push", "${_IMAGE_COLLECTOR}"]
-    id: PUSH_COLLECTOR
-    waitFor:
-      - BUILD_COLLECTOR
-
   - name: "ubuntu"
     env:
       - "IMAGE_APP=${_IMAGE_APP}"
-      - "IMAGE_COLLECTOR=${_IMAGE_COLLECTOR}"
-      - "PROJECT=${_GCP_PROJECT}"
     script: |
-      sed -i s@%OTELCOL_IMAGE%@${IMAGE_COLLECTOR}@g run-service-simple.yaml
       sed -i s@%SAMPLE_APP_IMAGE%@${IMAGE_APP}@g run-service-simple.yaml
     id: REPLACE_YAML_VALUE
     waitFor:
-      - PUSH_COLLECTOR
+      - PUSH_SAMPLE_APP
 
   - name: "gcr.io/google.com/cloudsdktool/cloud-sdk:slim"
     entrypoint: gcloud
@@ -61,7 +47,6 @@ steps:
     id: DEPLOY_MULTICONTAINER
     waitFor:
       - PUSH_SAMPLE_APP
-      - PUSH_COLLECTOR
       - REPLACE_YAML_VALUE
 
   - name: "gcr.io/google.com/cloudsdktool/cloud-sdk:slim"
@@ -86,12 +71,10 @@ substitutions:
   _GCP_PROJECT: ${PROJECT_ID}
   _REGISTRY: ${_REGION}-docker.pkg.dev/${_GCP_PROJECT}/run-gmp
   _IMAGE_APP: ${_REGISTRY}/sample-app
-  _IMAGE_COLLECTOR: ${_REGISTRY}/collector
   _SA_NAME: run-gmp-sa
 
 images:
   - ${_IMAGE_APP}
-  - ${_IMAGE_COLLECTOR}
 
 # comment out the following line if you want to run Cloud Build with the existing
 # service account with the following roles.

--- a/run-service-simple.yaml
+++ b/run-service-simple.yaml
@@ -22,7 +22,7 @@ spec:
   template:
     metadata:
       annotations:
-        run.googleapis.com/execution-environment: gen1
+        run.googleapis.com/execution-environment: gen2
         run.googleapis.com/cpu-throttling: 'false'
         run.googleapis.com/container-dependencies: '{"collector":["app"]}'
     spec:
@@ -39,5 +39,5 @@ spec:
             port: 8000
         ports:
         - containerPort: 8000
-      - image: "%OTELCOL_IMAGE%"
+      - image: us-docker.pkg.dev/cloud-ops-agents-artifacts/cloud-run-gmp-sidecar/cloud-run-gmp-sidecar:1.0.0
         name: collector

--- a/run-service.yaml
+++ b/run-service.yaml
@@ -22,7 +22,7 @@ spec:
   template:
     metadata:
       annotations:
-        run.googleapis.com/execution-environment: gen1
+        run.googleapis.com/execution-environment: gen2
         run.googleapis.com/cpu-throttling: 'false'
         run.googleapis.com/container-dependencies: '{"collector":["app"]}'
         run.googleapis.com/secrets: '%SECRET%:projects/%PROJECT%/secrets/%SECRET%'


### PR DESCRIPTION
Updates simple cloudbuild use case to public docs to use