### PR TITLE
confgenerator: add job name for endpoint config

### DIFF
--- a/confgenerator/config.go
+++ b/confgenerator/config.go
@@ -271,16 +271,11 @@ func (rc *RunMonitoringConfig) endpointScrapeConfig(index int) (*promconfig.Scra
 	}
 	relabelCfgs := relabelingsForMetadata(metadataLabels, rc.Env)
 
-	relabelCfgs = append(relabelCfgs, &relabel.Config{
-		Action:      relabel.Replace,
-		Replacement: rc.Name,
-		TargetLabel: "job",
-	})
-
 	jobName := fmt.Sprintf("run-gmp-sidecar-%d", index)
 
 	return endpointScrapeConfig(
 		jobName,
+		rc.Name,
 		rc.Spec.Endpoints[index],
 		relabelCfgs,
 		rc.Spec.Limits,
@@ -320,7 +315,7 @@ func relabelingsForMetadata(keys map[string]struct{}, env *CloudRunEnvironment) 
 	return res
 }
 
-func endpointScrapeConfig(id string, ep ScrapeEndpoint, relabelCfgs []*relabel.Config, limits *ScrapeLimits, env *CloudRunEnvironment) (*promconfig.ScrapeConfig, error) {
+func endpointScrapeConfig(id, cfgName string, ep ScrapeEndpoint, relabelCfgs []*relabel.Config, limits *ScrapeLimits, env *CloudRunEnvironment) (*promconfig.ScrapeConfig, error) {
 	if env == nil {
 		return nil, fmt.Errorf("metadata from Cloud Run was not found")
 	}
@@ -332,6 +327,11 @@ func endpointScrapeConfig(id string, ep ScrapeEndpoint, relabelCfgs []*relabel.C
 		},
 	}
 	relabelCfgs = append(relabelCfgs,
+		&relabel.Config{
+			Action:      relabel.Replace,
+			Replacement: cfgName,
+			TargetLabel: "job",
+		},
 		&relabel.Config{
 			Action:       relabel.Replace,
 			SourceLabels: prommodel.LabelNames{"__address__"},

--- a/confgenerator/config.go
+++ b/confgenerator/config.go
@@ -61,6 +61,8 @@ type RunTargetLabels struct {
 
 // ScrapeEndpoint specifies a Prometheus metrics endpoint to scrape.
 type ScrapeEndpoint struct {
+	// The job name to which the job label is set by default.
+	JobName string `yaml:"jobName,omitempty"`
 	// Name or number of the port to scrape.
 	Port string `yaml:"port"`
 	// Protocol scheme to use to scrape.
@@ -270,8 +272,12 @@ func (rc *RunMonitoringConfig) endpointScrapeConfig(index int) (*promconfig.Scra
 		}
 	}
 	relabelCfgs := relabelingsForMetadata(metadataLabels, rc.Env)
+	jobName := rc.Spec.Endpoints[index].JobName
+	if jobName == "" {
+		jobName = rc.ObjectMeta.Name
+	}
 	return endpointScrapeConfig(
-		rc.Name,
+		jobName,
 		rc.Spec.Endpoints[index],
 		relabelCfgs,
 		rc.Spec.Limits,

--- a/confgenerator/testdata/add-metadata-labels/golden/otel.yaml
+++ b/confgenerator/testdata/add-metadata-labels/golden/otel.yaml
@@ -91,7 +91,7 @@ receivers:
     allow_cumulative_resets: true
     config:
       scrape_configs:
-      - job_name: run-run-run
+      - job_name: run-gmp-sidecar-0
         honor_timestamps: false
         scrape_interval: 1m
         scrape_timeout: 1m
@@ -103,6 +103,9 @@ receivers:
         - source_labels: [__address__]
           target_label: service_name
           replacement: test_service
+          action: replace
+        - target_label: job
+          replacement: run-run-run
           action: replace
         - source_labels: [__address__]
           target_label: cluster

--- a/confgenerator/testdata/builtin/golden/otel.yaml
+++ b/confgenerator/testdata/builtin/golden/otel.yaml
@@ -96,7 +96,7 @@ receivers:
     allow_cumulative_resets: true
     config:
       scrape_configs:
-      - job_name: run-gmp-sidecar
+      - job_name: run-gmp-sidecar-0
         honor_timestamps: false
         scrape_interval: 30s
         scrape_timeout: 30s
@@ -115,6 +115,9 @@ receivers:
         - source_labels: [__address__]
           target_label: configuration_name
           replacement: test_configuration
+          action: replace
+        - target_label: job
+          replacement: run-gmp-sidecar
           action: replace
         - source_labels: [__address__]
           target_label: cluster

--- a/confgenerator/testdata/relabel-labels/golden/otel.yaml
+++ b/confgenerator/testdata/relabel-labels/golden/otel.yaml
@@ -96,7 +96,7 @@ receivers:
     allow_cumulative_resets: true
     config:
       scrape_configs:
-      - job_name: mycollector
+      - job_name: run-gmp-sidecar-0
         honor_timestamps: false
         scrape_interval: 10s
         scrape_timeout: 10s
@@ -115,6 +115,9 @@ receivers:
         - source_labels: [__address__]
           target_label: configuration_name
           replacement: test_configuration
+          action: replace
+        - target_label: job
+          replacement: mycollector
           action: replace
         - source_labels: [__address__]
           target_label: cluster

--- a/confgenerator/testdata/simple-app-scrape/golden/otel.yaml
+++ b/confgenerator/testdata/simple-app-scrape/golden/otel.yaml
@@ -96,7 +96,7 @@ receivers:
     allow_cumulative_resets: true
     config:
       scrape_configs:
-      - job_name: run-run-run
+      - job_name: endpoint-job-name
         honor_timestamps: false
         scrape_interval: 1m
         scrape_timeout: 1m

--- a/confgenerator/testdata/simple-app-scrape/golden/otel.yaml
+++ b/confgenerator/testdata/simple-app-scrape/golden/otel.yaml
@@ -96,7 +96,7 @@ receivers:
     allow_cumulative_resets: true
     config:
       scrape_configs:
-      - job_name: endpoint-job-name
+      - job_name: run-gmp-sidecar-0
         honor_timestamps: false
         scrape_interval: 1m
         scrape_timeout: 1m
@@ -115,6 +115,9 @@ receivers:
         - source_labels: [__address__]
           target_label: configuration_name
           replacement: test_configuration
+          action: replace
+        - target_label: job
+          replacement: run-run-run
           action: replace
         - source_labels: [__address__]
           target_label: cluster

--- a/confgenerator/testdata/simple-app-scrape/input.yaml
+++ b/confgenerator/testdata/simple-app-scrape/input.yaml
@@ -20,3 +20,4 @@ spec:
   endpoints:
   - port: 8080
     interval: 60s
+    jobName: endpoint-job-name

--- a/confgenerator/testdata/simple-app-scrape/input.yaml
+++ b/confgenerator/testdata/simple-app-scrape/input.yaml
@@ -20,4 +20,3 @@ spec:
   endpoints:
   - port: 8080
     interval: 60s
-    jobName: endpoint-job-name


### PR DESCRIPTION
Hello,

Sorry for the sudden PR.
I know you're not accepting contributions right now, but I hope you'll let me submit this PR to solve a problem I'm facing.
I'm trying out the use of gmp with the sidecar pattern on Cloud Run.
In the configuration, it seems to support multiple endpoints, but when specifying multiple exporter metric endpoints, the following error occurs and metric collection fails:

```
"* error decoding 'receivers': error reading configuration for "prometheus/application-metrics": prometheus receiver failed to unmarshal yaml to prometheus config: found multiple scrape configs with job name "run-gmp-sidecar"" 
```

I think the issue is because we're reusing the metav1.ObjectMeta.Name for each endpoint's configuration.
https://github.com/GoogleCloudPlatform/run-gmp-sidecar/blob/eb051f9cff4f04075a65b4ad361a34e93808db6b/confgenerator/config.go#L274

I tried using a gmp sidecar built with this commit and it worked.