### PR TITLE
Make docs use 1.1.1 as recommended version

### DIFF
--- a/run-service-simple.yaml
+++ b/run-service-simple.yaml
@@ -39,5 +39,5 @@ spec:
             port: 8000
         ports:
         - containerPort: 8000
-      - image: us-docker.pkg.dev/cloud-ops-agents-artifacts/cloud-run-gmp-sidecar/cloud-run-gmp-sidecar:1.0.0
+      - image: us-docker.pkg.dev/cloud-ops-agents-artifacts/cloud-run-gmp-sidecar/cloud-run-gmp-sidecar:1.1.1
         name: collector


### PR DESCRIPTION
I also filed b/336328313 so we don't have to do this every release. But didn't want to wait for that to be addressed for this release to be done.