### PR TITLE
confgenerator: allow relabelling project_id

### DIFF
--- a/collector/exporter/googlemanagedprometheusexporter/generated_component_test.go
+++ b/collector/exporter/googlemanagedprometheusexporter/generated_component_test.go
@@ -57,46 +57,6 @@ func TestComponentLifecycle(t *testing.T) {
 			err = c.Shutdown(context.Background())
 			require.NoError(t, err)
 		})
-		t.Run(test.name+"-lifecycle", func(t *testing.T) {
-			c, err := test.createFn(context.Background(), exportertest.NewNopCreateSettings(), cfg)
-			require.NoError(t, err)
-			host := componenttest.NewNopHost()
-			err = c.Start(context.Background(), host)
-			require.NoError(t, err)
-			require.NotPanics(t, func() {
-				switch test.name {
-				case "logs":
-					e, ok := c.(exporter.Logs)
-					require.True(t, ok)
-					logs := generateLifecycleTestLogs()
-					if !e.Capabilities().MutatesData {
-						logs.MarkReadOnly()
-					}
-					err = e.ConsumeLogs(context.Background(), logs)
-				case "metrics":
-					e, ok := c.(exporter.Metrics)
-					require.True(t, ok)
-					metrics := generateLifecycleTestMetrics()
-					if !e.Capabilities().MutatesData {
-						metrics.MarkReadOnly()
-					}
-					err = e.ConsumeMetrics(context.Background(), metrics)
-				case "traces":
-					e, ok := c.(exporter.Traces)
-					require.True(t, ok)
-					traces := generateLifecycleTestTraces()
-					if !e.Capabilities().MutatesData {
-						traces.MarkReadOnly()
-					}
-					err = e.ConsumeTraces(context.Background(), traces)
-				}
-			})
-
-			require.NoError(t, err)
-
-			err = c.Shutdown(context.Background())
-			require.NoError(t, err)
-		})
 	}
 }
 

--- a/collector/exporter/googlemanagedprometheusexporter/generated_package_test.go
+++ b/collector/exporter/googlemanagedprometheusexporter/generated_package_test.go
@@ -8,5 +8,5 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	goleak.VerifyTestMain(m)
+	goleak.VerifyTestMain(m, goleak.IgnoreTopFunction("go.opencensus.io/stats/view.(*worker).start"))
 }

--- a/collector/exporter/googlemanagedprometheusexporter/metadata.yaml
+++ b/collector/exporter/googlemanagedprometheusexporter/metadata.yaml
@@ -6,3 +6,11 @@ status:
   stability:
     beta: [metrics]
   distributions: [contrib, observiq]
+
+tests:
+  skip_lifecycle: true
+  goleak:
+    ignore:
+      top:
+        # See https://github.com/census-instrumentation/opencensus-go/issues/1191 for more information.
+        - "go.opencensus.io/stats/view.(*worker).start"

--- a/collector/receiver/prometheusreceiver/config_test.go
+++ b/collector/receiver/prometheusreceiver/config_test.go
@@ -26,6 +26,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/confmap/confmaptest"
+
+	"github.com/GoogleCloudPlatform/run-gmp-sidecar/collector/receiver/prometheusreceiver/internal/metadata"
 )
 
 func TestLoadConfig(t *testing.T) {
@@ -34,14 +36,14 @@ func TestLoadConfig(t *testing.T) {
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
 
-	sub, err := cm.Sub(component.NewIDWithName(typeStr, "").String())
+	sub, err := cm.Sub(component.NewIDWithName(metadata.Type, "").String())
 	require.NoError(t, err)
 	require.NoError(t, component.UnmarshalConfig(sub, cfg))
 
 	r0 := cfg.(*Config)
 	assert.Equal(t, r0, factory.CreateDefaultConfig())
 
-	sub, err = cm.Sub(component.NewIDWithName(typeStr, "customname").String())
+	sub, err = cm.Sub(component.NewIDWithName(metadata.Type, "customname").String())
 	require.NoError(t, err)
 	require.NoError(t, component.UnmarshalConfig(sub, cfg))
 
@@ -66,7 +68,7 @@ func TestLoadTargetAllocatorConfig(t *testing.T) {
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
 
-	sub, err := cm.Sub(component.NewIDWithName(typeStr, "").String())
+	sub, err := cm.Sub(component.NewIDWithName(metadata.Type, "").String())
 	require.NoError(t, err)
 	require.NoError(t, component.UnmarshalConfig(sub, cfg))
 
@@ -76,7 +78,7 @@ func TestLoadTargetAllocatorConfig(t *testing.T) {
 	assert.Equal(t, 30*time.Second, r0.TargetAllocator.Interval)
 	assert.Equal(t, "collector-1", r0.TargetAllocator.CollectorID)
 
-	sub, err = cm.Sub(component.NewIDWithName(typeStr, "withScrape").String())
+	sub, err = cm.Sub(component.NewIDWithName(metadata.Type, "withScrape").String())
 	require.NoError(t, err)
 	cfg = factory.CreateDefaultConfig()
 	require.NoError(t, component.UnmarshalConfig(sub, cfg))
@@ -91,7 +93,7 @@ func TestLoadTargetAllocatorConfig(t *testing.T) {
 	assert.Equal(t, "demo", r1.PrometheusConfig.ScrapeConfigs[0].JobName)
 	assert.Equal(t, promModel.Duration(5*time.Second), r1.PrometheusConfig.ScrapeConfigs[0].ScrapeInterval)
 
-	sub, err = cm.Sub(component.NewIDWithName(typeStr, "withOnlyScrape").String())
+	sub, err = cm.Sub(component.NewIDWithName(metadata.Type, "withOnlyScrape").String())
 	require.NoError(t, err)
 	cfg = factory.CreateDefaultConfig()
 	require.NoError(t, component.UnmarshalConfig(sub, cfg))
@@ -108,7 +110,7 @@ func TestLoadConfigFailsOnUnknownSection(t *testing.T) {
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
 
-	sub, err := cm.Sub(component.NewIDWithName(typeStr, "").String())
+	sub, err := cm.Sub(component.NewIDWithName(metadata.Type, "").String())
 	require.NoError(t, err)
 	require.Error(t, component.UnmarshalConfig(sub, cfg))
 }
@@ -122,7 +124,7 @@ func TestLoadConfigFailsOnUnknownPrometheusSection(t *testing.T) {
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
 
-	sub, err := cm.Sub(component.NewIDWithName(typeStr, "").String())
+	sub, err := cm.Sub(component.NewIDWithName(metadata.Type, "").String())
 	require.NoError(t, err)
 	require.Error(t, component.UnmarshalConfig(sub, cfg))
 }
@@ -134,7 +136,7 @@ func TestLoadConfigFailsOnRenameDisallowed(t *testing.T) {
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
 
-	sub, err := cm.Sub(component.NewIDWithName(typeStr, "").String())
+	sub, err := cm.Sub(component.NewIDWithName(metadata.Type, "").String())
 	require.NoError(t, err)
 	require.NoError(t, component.UnmarshalConfig(sub, cfg))
 	assert.Error(t, component.ValidateConfig(cfg))
@@ -147,7 +149,7 @@ func TestRejectUnsupportedPrometheusFeatures(t *testing.T) {
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
 
-	sub, err := cm.Sub(component.NewIDWithName(typeStr, "").String())
+	sub, err := cm.Sub(component.NewIDWithName(metadata.Type, "").String())
 	require.NoError(t, err)
 	require.NoError(t, component.UnmarshalConfig(sub, cfg))
 
@@ -172,7 +174,7 @@ func TestNonExistentAuthCredentialsFile(t *testing.T) {
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
 
-	sub, err := cm.Sub(component.NewIDWithName(typeStr, "").String())
+	sub, err := cm.Sub(component.NewIDWithName(metadata.Type, "").String())
 	require.NoError(t, err)
 	require.NoError(t, component.UnmarshalConfig(sub, cfg))
 
@@ -191,7 +193,7 @@ func TestTLSConfigNonExistentCertFile(t *testing.T) {
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
 
-	sub, err := cm.Sub(component.NewIDWithName(typeStr, "").String())
+	sub, err := cm.Sub(component.NewIDWithName(metadata.Type, "").String())
 	require.NoError(t, err)
 	require.NoError(t, component.UnmarshalConfig(sub, cfg))
 
@@ -210,7 +212,7 @@ func TestTLSConfigNonExistentKeyFile(t *testing.T) {
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
 
-	sub, err := cm.Sub(component.NewIDWithName(typeStr, "").String())
+	sub, err := cm.Sub(component.NewIDWithName(metadata.Type, "").String())
 	require.NoError(t, err)
 	require.NoError(t, component.UnmarshalConfig(sub, cfg))
 
@@ -229,7 +231,7 @@ func TestTLSConfigCertFileWithoutKeyFile(t *testing.T) {
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
 
-	sub, err := cm.Sub(component.NewIDWithName(typeStr, "").String())
+	sub, err := cm.Sub(component.NewIDWithName(metadata.Type, "").String())
 	require.NoError(t, err)
 	err = component.UnmarshalConfig(sub, cfg)
 	if assert.Error(t, err) {
@@ -243,7 +245,7 @@ func TestTLSConfigKeyFileWithoutCertFile(t *testing.T) {
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
 
-	sub, err := cm.Sub(component.NewIDWithName(typeStr, "").String())
+	sub, err := cm.Sub(component.NewIDWithName(metadata.Type, "").String())
 	require.NoError(t, err)
 	err = component.UnmarshalConfig(sub, cfg)
 	if assert.Error(t, err) {
@@ -257,7 +259,7 @@ func TestKubernetesSDConfigWithoutKeyFile(t *testing.T) {
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
 
-	sub, err := cm.Sub(component.NewIDWithName(typeStr, "").String())
+	sub, err := cm.Sub(component.NewIDWithName(metadata.Type, "").String())
 	require.NoError(t, err)
 	err = component.UnmarshalConfig(sub, cfg)
 	if assert.Error(t, err) {
@@ -271,7 +273,7 @@ func TestFileSDConfigJsonNilTargetGroup(t *testing.T) {
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
 
-	sub, err := cm.Sub(component.NewIDWithName(typeStr, "").String())
+	sub, err := cm.Sub(component.NewIDWithName(metadata.Type, "").String())
 	require.NoError(t, err)
 	require.NoError(t, component.UnmarshalConfig(sub, cfg))
 
@@ -290,7 +292,7 @@ func TestFileSDConfigYamlNilTargetGroup(t *testing.T) {
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
 
-	sub, err := cm.Sub(component.NewIDWithName(typeStr, "").String())
+	sub, err := cm.Sub(component.NewIDWithName(metadata.Type, "").String())
 	require.NoError(t, err)
 	require.NoError(t, component.UnmarshalConfig(sub, cfg))
 

--- a/collector/receiver/prometheusreceiver/generated_package_test.go
+++ b/collector/receiver/prometheusreceiver/generated_package_test.go
@@ -8,5 +8,5 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	goleak.VerifyTestMain(m)
+	goleak.VerifyTestMain(m, goleak.IgnoreTopFunction("go.opencensus.io/stats/view.(*worker).start"))
 }

--- a/collector/receiver/prometheusreceiver/internal/staleness_end_to_end_test.go
+++ b/collector/receiver/prometheusreceiver/internal/staleness_end_to_end_test.go
@@ -158,19 +158,14 @@ service:
 		Processors: processors,
 	}
 
-	fmp := fileprovider.New()
-	configProvider, err := otelcol.NewConfigProvider(
-		otelcol.ConfigProviderSettings{
-			ResolverSettings: confmap.ResolverSettings{
-				URIs:      []string{confFile.Name()},
-				Providers: map[string]confmap.Provider{fmp.Scheme(): fmp},
-			},
-		})
-	require.NoError(t, err)
-
 	appSettings := otelcol.CollectorSettings{
-		Factories:      func() (otelcol.Factories, error) { return factories, nil },
-		ConfigProvider: configProvider,
+		Factories: func() (otelcol.Factories, error) { return factories, nil },
+		ConfigProviderSettings: otelcol.ConfigProviderSettings{
+			ResolverSettings: confmap.ResolverSettings{
+				URIs:              []string{confFile.Name()},
+				ProviderFactories: []confmap.ProviderFactory{fileprovider.NewFactory()},
+			},
+		},
 		BuildInfo: component.BuildInfo{
 			Command:     "otelcol",
 			Description: "OpenTelemetry Collector",

--- a/collector/receiver/prometheusreceiver/internal/transaction_test.go
+++ b/collector/receiver/prometheusreceiver/internal/transaction_test.go
@@ -264,7 +264,7 @@ func TestAppendExemplarWithEmptyLabelArray(t *testing.T) {
 
 func nopObsRecv(t *testing.T) *receiverhelper.ObsReport {
 	obsrecv, err := receiverhelper.NewObsReport(receiverhelper.ObsReportSettings{
-		ReceiverID:             component.NewID("prometheus"),
+		ReceiverID:             component.MustNewID("prometheus"),
 		Transport:              transport,
 		ReceiverCreateSettings: receivertest.NewNopCreateSettings(),
 	})

--- a/collector/receiver/prometheusreceiver/metadata.yaml
+++ b/collector/receiver/prometheusreceiver/metadata.yaml
@@ -6,3 +6,14 @@ status:
   stability:
     beta: [metrics]
   distributions: [core, contrib]
+
+tests:
+  config:
+    config:
+      scrape_configs:
+        - job_name: 'test'
+  goleak:
+    ignore:
+      top:
+        # See https://github.com/census-instrumentation/opencensus-go/issues/1191 for more information.
+        - "go.opencensus.io/stats/view.(*worker).start"

--- a/confgenerator/config.go
+++ b/confgenerator/config.go
@@ -217,6 +217,10 @@ func (rc *RunMonitoringConfig) OTelReceiverPipeline() (*otel.ReceiverPipeline, e
 	// Group by the GMP attributes.
 	processors = append(processors, otel.GroupByGMPAttrs())
 
+	// If the user updates the `project_id` label, we need to update the gcp.project.id resource attribute
+	// so the exporter can pick it up.
+	processors = append(processors, otel.TransformationMetrics(otel.GroupByAttribute("gcp.project.id", "project_id"), otel.DeleteMetricAttribute("project_id")))
+
 	return &otel.ReceiverPipeline{
 		Receiver: otel.Component{
 			Type: "prometheus",

--- a/confgenerator/otel/processors.go
+++ b/confgenerator/otel/processors.go
@@ -179,6 +179,16 @@ func FlattenResourceAttribute(resourceAttribute, metricAttribute string) Transfo
 	return TransformQuery(fmt.Sprintf(`set(attributes["%s"], resource.attributes["%s"])`, metricAttribute, resourceAttribute))
 }
 
+// GroupByAttribute returns an expression that makes a metric attribute into a resource attribute.
+func GroupByAttribute(resourceAttribute, metricAttribute string) TransformQuery {
+	return TransformQuery(fmt.Sprintf(`set(resource.attributes["%s"], attributes["%s"]) where attributes["%s"] != nil`, resourceAttribute, metricAttribute, metricAttribute))
+}
+
+// DeleteMetricAttribute returns an expression that removes the metric attribute specified.
+func DeleteMetricAttribute(metricAttribute string) TransformQuery {
+	return TransformQuery(fmt.Sprintf(`delete_key(attributes, "%s")`, metricAttribute))
+}
+
 // PrefixResourceAttribute prefixes the resource attribute with another resource
 // attribute.
 //

--- a/confgenerator/testdata/builtin/golden/otel.yaml
+++ b/confgenerator/testdata/builtin/golden/otel.yaml
@@ -83,6 +83,13 @@ processors:
       context: datapoint
       statements:
       - set(attributes["instanceId"], resource.attributes["faas.id"])
+  transform/application-metrics_4:
+    metric_statements:
+      context: datapoint
+      statements:
+      - set(resource.attributes["gcp.project.id"], attributes["project_id"]) where
+        attributes["project_id"] != nil
+      - delete_key(attributes, "project_id")
   transform/run-gmp-self-metrics_3:
     metric_statements:
       context: datapoint
@@ -103,6 +110,7 @@ receivers:
         metrics_path: /metrics
         follow_redirects: false
         enable_http2: false
+        http_headers: null
         relabel_configs:
         - source_labels: [__address__]
           target_label: service_name
@@ -161,6 +169,7 @@ service:
       - transform/application-metrics_1
       - transform/application-metrics_2
       - groupbyattrs/application-metrics_3
+      - transform/application-metrics_4
       receivers:
       - prometheus/application-metrics
     metrics/run-gmp-self-metrics:

--- a/confgenerator/testdata/relabel-labels/golden/otel.yaml
+++ b/confgenerator/testdata/relabel-labels/golden/otel.yaml
@@ -83,6 +83,13 @@ processors:
       context: datapoint
       statements:
       - set(attributes["instanceId"], resource.attributes["faas.id"])
+  transform/application-metrics_4:
+    metric_statements:
+      context: datapoint
+      statements:
+      - set(resource.attributes["gcp.project.id"], attributes["project_id"]) where
+        attributes["project_id"] != nil
+      - delete_key(attributes, "project_id")
   transform/run-gmp-self-metrics_3:
     metric_statements:
       context: datapoint
@@ -103,6 +110,7 @@ receivers:
         metrics_path: /metrics
         follow_redirects: false
         enable_http2: false
+        http_headers: null
         relabel_configs:
         - source_labels: [__address__]
           target_label: service_name
@@ -165,6 +173,7 @@ service:
       - transform/application-metrics_1
       - transform/application-metrics_2
       - groupbyattrs/application-metrics_3
+      - transform/application-metrics_4
       receivers:
       - prometheus/application-metrics
     metrics/run-gmp-self-metrics:

--- a/confgenerator/testdata/relabel_project_id/golden/otel.yaml
+++ b/confgenerator/testdata/relabel_project_id/golden/otel.yaml
@@ -14,7 +14,7 @@ processors:
         - otelcol_process_memory_rss
         - otelcol_grpc_io_client_completed_rpcs
         - otelcol_googlecloudmonitoring_point_count
-  groupbyattrs/application-metrics_2:
+  groupbyattrs/application-metrics_3:
     keys:
     - namespace
     - cluster
@@ -78,7 +78,12 @@ processors:
       statements:
       - replace_pattern(resource.attributes["service.instance.id"], "^(\\d+)$$", Concat([resource.attributes["faas.id"],
         "$$1"], ":"))
-  transform/application-metrics_3:
+  transform/application-metrics_2:
+    metric_statements:
+      context: datapoint
+      statements:
+      - set(attributes["instanceId"], resource.attributes["faas.id"])
+  transform/application-metrics_4:
     metric_statements:
       context: datapoint
       statements:
@@ -100,10 +105,9 @@ receivers:
       scrape_configs:
       - job_name: run-gmp-sidecar-0
         honor_timestamps: false
-        scrape_interval: 1m
-        scrape_timeout: 1m
+        scrape_interval: 10s
+        scrape_timeout: 10s
         metrics_path: /metrics
-        sample_limit: 1000
         follow_redirects: false
         enable_http2: false
         http_headers: null
@@ -112,8 +116,16 @@ receivers:
           target_label: service_name
           replacement: test_service
           action: replace
+        - source_labels: [__address__]
+          target_label: revision_name
+          replacement: test_revision
+          action: replace
+        - source_labels: [__address__]
+          target_label: configuration_name
+          replacement: test_configuration
+          action: replace
         - target_label: job
-          replacement: run-run-run
+          replacement: mycollector
           action: replace
         - source_labels: [__address__]
           target_label: cluster
@@ -126,6 +138,10 @@ receivers:
         - source_labels: [__address__]
           target_label: instance
           replacement: "8080"
+          action: replace
+        metric_relabel_configs:
+        - source_labels: [some_label]
+          target_label: project_id
           action: replace
         static_configs:
         - targets:
@@ -155,8 +171,9 @@ service:
       processors:
       - resourcedetection/application-metrics_0
       - transform/application-metrics_1
-      - groupbyattrs/application-metrics_2
-      - transform/application-metrics_3
+      - transform/application-metrics_2
+      - groupbyattrs/application-metrics_3
+      - transform/application-metrics_4
       receivers:
       - prometheus/application-metrics
     metrics/run-gmp-self-metrics:

--- a/confgenerator/testdata/relabel_project_id/input.yaml
+++ b/confgenerator/testdata/relabel_project_id/input.yaml
@@ -1,0 +1,30 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: monitoring.googleapis.com/v1beta
+kind: RunMonitoring
+metadata:
+  name: mycollector
+  labels:
+    run-app: mycollector
+    type: mytype
+spec:
+  endpoints:
+  - port: 8080
+    interval: 10s
+    metricRelabeling:
+    - action: replace
+      sourceLabels:
+      - some_label
+      targetLabel: project_id

--- a/confgenerator/testdata/simple-app-scrape/golden/otel.yaml
+++ b/confgenerator/testdata/simple-app-scrape/golden/otel.yaml
@@ -83,6 +83,13 @@ processors:
       context: datapoint
       statements:
       - set(attributes["instanceId"], resource.attributes["faas.id"])
+  transform/application-metrics_4:
+    metric_statements:
+      context: datapoint
+      statements:
+      - set(resource.attributes["gcp.project.id"], attributes["project_id"]) where
+        attributes["project_id"] != nil
+      - delete_key(attributes, "project_id")
   transform/run-gmp-self-metrics_3:
     metric_statements:
       context: datapoint
@@ -103,6 +110,7 @@ receivers:
         metrics_path: /metrics
         follow_redirects: false
         enable_http2: false
+        http_headers: null
         relabel_configs:
         - source_labels: [__address__]
           target_label: service_name
@@ -161,6 +169,7 @@ service:
       - transform/application-metrics_1
       - transform/application-metrics_2
       - groupbyattrs/application-metrics_3
+      - transform/application-metrics_4
       receivers:
       - prometheus/application-metrics
     metrics/run-gmp-self-metrics:

--- a/confgenerator/util.go
+++ b/confgenerator/util.go
@@ -105,7 +105,6 @@ func contains(s []string, str string) bool {
 // as that is a curated label that is added in a processor (later in the
 // pipeline) - so its not available during relabeling in the receiver.
 var protectedLabels = []string{
-	"project_id",
 	"location",
 	"cluster",
 	"namespace",

--- a/integration_test/collector_test.go
+++ b/integration_test/collector_test.go
@@ -368,13 +368,11 @@ func contains(s []int, e int) bool {
 }
 
 func getAvailablePort(t *testing.T, excludePorts []int) int {
-	port, err := confgenerator.GetFreePort()
-	require.NoError(t, err)
 	for {
+		port, err := confgenerator.GetFreePort()
+		require.NoError(t, err)
 		if !contains(excludePorts, port) {
 			return port
 		}
-		port, err = confgenerator.GetFreePort()
-		require.NoError(t, err)
 	}
 }


### PR DESCRIPTION
Fixes b/339498134

This change does the following:
- Removes validation that prevents the project_id being relabelled
- Moves the project_id to the `gcp.project.id` resource attribute so the exporter can set it correctly in the monitored resource label
- Adds a confgenerator test
- Fix broken prometheus tests

This is being tested by running the sidecar in one project and sending the metrics to another using a relabel rule.

Self metrics:
screen/8wNBTeKuUfuAgyL

Service metrics (sent to a different project):
screen/3FubQ698D2PX6Cs

Config used:
```
apiVersion: monitoring.googleapis.com/v1beta
kind: RunMonitoring
metadata:
  name: mycollector
spec:
  endpoints:
  - port: 8080
    interval: 10s
    metricRelabeling:
    - action: replace
      targetLabel: project_id
      replacement: ridwanmsharif-dev
```

Change-Id: I930e8c985c48491f6debb8181432b3b5c3646c05