### PR TITLE
Add New Relic integration for run-gmp-sidecar

### DIFF
--- a/Dockerfile.newrelic
+++ b/Dockerfile.newrelic
@@ -1,0 +1,33 @@
+# Multi-stage Dockerfile for New Relic version of run-gmp-sidecar
+FROM golang:1.23.0 as builder
+
+WORKDIR /sidecar
+COPY . .
+
+# Install build dependencies
+RUN apt-get update && apt-get install -y gettext-base make
+
+# Install Go tools needed for build
+RUN go install github.com/client9/misspell/cmd/misspell@v0.3.4 \
+    && go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.52.1 \
+    && go install github.com/google/addlicense@v1.0.0
+
+# Build the New Relic version
+RUN make build
+
+# Get certificates for HTTPS calls to New Relic
+FROM alpine:latest AS certs
+RUN apk --update add ca-certificates
+
+# Final minimal image
+FROM scratch
+
+# Copy certificates
+COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+
+# Copy built binaries
+COPY --from=builder /sidecar/bin/rungmpcol /rungmpcol
+COPY --from=builder /sidecar/bin/run-gmp-entrypoint /run-gmp-entrypoint
+
+# Use the entrypoint which will start the collector
+ENTRYPOINT ["/run-gmp-entrypoint"]

--- a/README-NewRelic.md
+++ b/README-NewRelic.md
@@ -1,0 +1,189 @@
+# New Relic Integration for run-gmp-sidecar
+
+This repository has been adapted to send metrics to New Relic instead of Google Cloud Monitoring, while maintaining all the existing functionality and patterns of the original Google GMP Sidecar.
+
+## What Changed
+
+### Key Modifications
+
+1. **New Relic Exporter**: Added a custom OpenTelemetry exporter (`collector/exporter/newrelicexporter`) that formats metrics for New Relic's Metric API
+2. **Configuration Update**: Modified the config generator to use the New Relic exporter instead of Google Managed Prometheus
+3. **Environment Variables**: Added support for New Relic API key and service metadata via environment variables
+4. **Deployment Scripts**: Created new deployment scripts and configurations for New Relic setup
+
+### Architecture
+
+```
+┌─────────────────┐    ┌──────────────────┐    ┌─────────────────┐
+│   Your App     │    │  Sidecar         │    │   New Relic     │
+│                │    │                  │    │                 │
+│  Port 8080     │───▶│  Prometheus      │───▶│   Metric API    │
+│  /metrics      │    │  Receiver        │    │                 │
+│                │    │                  │    │                 │
+└─────────────────┘    │  New Relic       │    └─────────────────┘
+                       │  Exporter        │
+                       └──────────────────┘
+```
+
+## Quick Start
+
+### Prerequisites
+
+1. **New Relic Account**: You need a New Relic account and an Insights Insert API key
+2. **Google Cloud**: GCP project with Cloud Run and Artifact Registry APIs enabled
+3. **Docker**: For building container images
+
+### 1. Get Your New Relic API Key
+
+1. Log into your New Relic account
+2. Go to **Settings** → **API Keys**
+3. Create or copy an **Insights Insert API Key**
+4. Set it as an environment variable:
+   ```bash
+   export NEW_RELIC_API_KEY="your-api-key-here"
+   ```
+
+### 2. Deploy to Cloud Run
+
+```bash
+# Set your GCP project
+export GCP_PROJECT="your-project-id"
+export REGION="us-east1"
+
+# Run the setup script
+./setup-newrelic-simple.sh
+```
+
+The setup script will:
+- Create necessary secrets in Google Secret Manager
+- Build and push container images
+- Deploy your service to Cloud Run
+- Configure the New Relic integration
+
+### 3. Test Your Deployment
+
+```bash
+# Get your service URL
+SERVICE_URL=$(gcloud run services describe my-cloud-run-service-newrelic --region=$REGION --format="value(status.url)")
+
+# Test the endpoint
+curl $SERVICE_URL
+```
+
+### 4. View Metrics in New Relic
+
+1. Log into your New Relic account
+2. Navigate to **Metrics & Events**
+3. Look for metrics from your service (they should appear within a few minutes)
+
+## Configuration
+
+### Environment Variables
+
+The New Relic exporter supports these environment variables:
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `NEW_RELIC_API_KEY` | ✅ | - | Your New Relic Insights Insert API key |
+| `SERVICE_NAME` | ❌ | `run-gmp-sidecar` | Name of your service |
+| `SERVICE_VERSION` | ❌ | `1.0.0` | Version of your service |
+| `ENVIRONMENT` | ❌ | `production` | Deployment environment |
+
+### Volume Mount NOT Required!
+
+Unlike many monitoring solutions, this New Relic integration works with **no volume mounts needed**! The sidecar uses a default configuration that scrapes `0.0.0.0:8080/metrics` every 30 seconds. Perfect for simple deployments.
+
+## Metrics Format
+
+### Prometheus to New Relic Mapping
+
+The exporter automatically converts Prometheus metrics to New Relic format:
+
+| Prometheus Type | New Relic Type | Notes |
+|----------------|----------------|-------|
+| Gauge | `gauge` | Direct mapping |
+| Counter | `count` | Cumulative counters |
+| Histogram | `distribution` | With bucket data |
+| Summary | `summary` | With quantile data |
+
+### Example Metrics
+
+Your application metrics will appear in New Relic with these attributes:
+
+```json
+{
+  "name": "foo_metric",
+  "type": "gauge", 
+  "value": 123.45,
+  "timestamp": 1640995200,
+  "attributes": {
+    "service.name": "my-cloud-run-service",
+    "service.version": "1.0.0",
+    "deployment.environment": "production",
+    "job": "my-app",
+    "instance": "localhost:8080"
+  }
+}
+```
+
+## Monitoring and Troubleshooting
+
+### Check Logs
+
+```bash
+# View sidecar logs
+gcloud run services logs tail my-cloud-run-service-newrelic --region=$REGION
+
+# Filter for New Relic exporter logs
+gcloud run services logs tail my-cloud-run-service-newrelic --region=$REGION | grep newrelic
+```
+
+### Verify Configuration
+
+```bash
+# Check if API key secret exists
+gcloud secrets describe newrelic-secrets
+
+# View the secret value (be careful!)
+gcloud secrets versions access latest --secret=newrelic-secrets
+```
+
+### Common Issues
+
+1. **No metrics appearing in New Relic**
+   - Verify API key is correct
+   - Check service logs for authentication errors
+   - Ensure your app is exposing metrics on `/metrics`
+
+2. **High memory usage**
+   - Increase memory limits in `run-service-newrelic-simple.yaml`
+   - Reduce scraping frequency in your config
+
+3. **Authentication errors**
+   - Verify the API key has Insights Insert permissions
+   - Check that the secret is properly mounted
+
+## Migration from GMP
+
+If you're migrating from the original Google Managed Prometheus setup:
+
+1. **No changes needed** to your application code or metrics format
+2. **Keep existing** RunMonitoring configurations
+3. **Update environment variables** to use New Relic instead of GCP
+4. **Change dashboards** from Cloud Monitoring to New Relic
+
+### Side-by-Side Comparison
+
+| Feature | Original GMP | New Relic Version |
+|---------|-------------|-------------------|
+| Prometheus scraping | ✅ | ✅ (unchanged) |
+| Custom configs | ✅ | ✅ (unchanged) |
+| Sidecar pattern | ✅ | ✅ (unchanged) |
+| Cloud Run integration | ✅ | ✅ (unchanged) |
+| Volume mounts | Required | **NOT Required!** |
+| Destination | Google Cloud Monitoring | New Relic |
+| API Key | GCP Service Account | New Relic Insert Key |
+
+## License
+
+This project maintains the same Apache 2.0 license as the original Google run-gmp-sidecar project.

--- a/collector/exporter/newrelicexporter/config.go
+++ b/collector/exporter/newrelicexporter/config.go
@@ -1,0 +1,95 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package newrelicexporter
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"time"
+
+	"go.opentelemetry.io/collector/config/confighttp"
+	"go.opentelemetry.io/collector/exporter/exporterhelper"
+)
+
+// Config defines configuration for New Relic exporter.
+type Config struct {
+	confighttp.ClientConfig       `mapstructure:",squash"`
+	exporterhelper.QueueSettings  `mapstructure:"sending_queue"`
+	exporterhelper.RetrySettings  `mapstructure:"retry_on_failure"`
+	exporterhelper.TimeoutSettings `mapstructure:",squash"`
+
+	// APIKey is the New Relic Insights Insert API key
+	APIKey string `mapstructure:"api_key"`
+	
+	// MetricsURLOverride overrides the default New Relic metrics endpoint URL
+	MetricsURLOverride string `mapstructure:"metrics_url_override"`
+	
+	// LogsURLOverride overrides the default New Relic logs endpoint URL  
+	LogsURLOverride string `mapstructure:"logs_url_override"`
+	
+	// TracesURLOverride overrides the default New Relic traces endpoint URL
+	TracesURLOverride string `mapstructure:"traces_url_override"`
+	
+	// CommonAttributes are attributes to be included with every metric
+	CommonAttributes map[string]interface{} `mapstructure:"common_attributes"`
+}
+
+const (
+	defaultMetricsURL = "https://metric-api.newrelic.com/metric/v1"
+	defaultLogsURL    = "https://log-api.newrelic.com/log/v1" 
+	defaultTracesURL  = "https://trace-api.newrelic.com/trace/v1"
+)
+
+// Validate checks if the exporter configuration is valid
+func (cfg *Config) Validate() error {
+	if cfg.APIKey == "" {
+		return errors.New("api_key is required")
+	}
+
+	// Validate custom URLs if provided
+	if cfg.MetricsURLOverride != "" {
+		if _, err := url.Parse(cfg.MetricsURLOverride); err != nil {
+			return fmt.Errorf("invalid metrics_url_override: %w", err)
+		}
+	}
+	
+	if cfg.LogsURLOverride != "" {
+		if _, err := url.Parse(cfg.LogsURLOverride); err != nil {
+			return fmt.Errorf("invalid logs_url_override: %w", err)
+		}
+	}
+	
+	if cfg.TracesURLOverride != "" {
+		if _, err := url.Parse(cfg.TracesURLOverride); err != nil {
+			return fmt.Errorf("invalid traces_url_override: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// GetMetricsURL returns the metrics endpoint URL
+func (cfg *Config) GetMetricsURL() string {
+	if cfg.MetricsURLOverride != "" {
+		return cfg.MetricsURLOverride
+	}
+	return defaultMetricsURL
+}
+
+// GetLogsURL returns the logs endpoint URL  
+func (cfg *Config) GetLogsURL() string {
+	if cfg.LogsURLOverride != "" {
+		return cfg.LogsURLOverride
+	}
+	return defaultLogsURL
+}
+
+// GetTracesURL returns the traces endpoint URL
+func (cfg *Config) GetTracesURL() string {
+	if cfg.TracesURLOverride != "" {
+		return cfg.TracesURLOverride
+	}
+	return defaultTracesURL
+}

--- a/collector/exporter/newrelicexporter/exporter.go
+++ b/collector/exporter/newrelicexporter/exporter.go
@@ -1,0 +1,466 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package newrelicexporter
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/exporter"
+	"go.opentelemetry.io/collector/exporter/exporterhelper"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/plog"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+	"go.uber.org/zap"
+)
+
+type newrelicExporter struct {
+	cfg    *Config
+	logger *zap.Logger
+	client *http.Client
+}
+
+func newMetricsExporter(cfg *Config, set exporter.CreateSettings) (exporter.Metrics, error) {
+	ne := &newrelicExporter{
+		cfg:    cfg,
+		logger: set.Logger,
+		client: &http.Client{Timeout: cfg.Timeout},
+	}
+
+	return exporterhelper.NewMetricsExporter(
+		context.Background(),
+		set,
+		cfg,
+		ne.pushMetrics,
+		exporterhelper.WithQueue(cfg.QueueSettings),
+		exporterhelper.WithRetry(cfg.RetrySettings),
+		exporterhelper.WithTimeout(cfg.TimeoutSettings),
+	)
+}
+
+func newLogsExporter(cfg *Config, set exporter.CreateSettings) (exporter.Logs, error) {
+	ne := &newrelicExporter{
+		cfg:    cfg,
+		logger: set.Logger,
+		client: &http.Client{Timeout: cfg.Timeout},
+	}
+
+	return exporterhelper.NewLogsExporter(
+		context.Background(),
+		set,
+		cfg,
+		ne.pushLogs,
+		exporterhelper.WithQueue(cfg.QueueSettings),
+		exporterhelper.WithRetry(cfg.RetrySettings),
+		exporterhelper.WithTimeout(cfg.TimeoutSettings),
+	)
+}
+
+func newTracesExporter(cfg *Config, set exporter.CreateSettings) (exporter.Traces, error) {
+	ne := &newrelicExporter{
+		cfg:    cfg,
+		logger: set.Logger,
+		client: &http.Client{Timeout: cfg.Timeout},
+	}
+
+	return exporterhelper.NewTracesExporter(
+		context.Background(),
+		set,
+		cfg,
+		ne.pushTraces,
+		exporterhelper.WithQueue(cfg.QueueSettings),
+		exporterhelper.WithRetry(cfg.RetrySettings),
+		exporterhelper.WithTimeout(cfg.TimeoutSettings),
+	)
+}
+
+func (ne *newrelicExporter) pushMetrics(ctx context.Context, md pmetric.Metrics) error {
+	payload, err := ne.transformMetrics(md)
+	if err != nil {
+		return fmt.Errorf("failed to transform metrics: %w", err)
+	}
+
+	return ne.sendToNewRelic(ctx, ne.cfg.GetMetricsURL(), payload)
+}
+
+func (ne *newrelicExporter) pushLogs(ctx context.Context, ld plog.Logs) error {
+	payload, err := ne.transformLogs(ld)
+	if err != nil {
+		return fmt.Errorf("failed to transform logs: %w", err)
+	}
+
+	return ne.sendToNewRelic(ctx, ne.cfg.GetLogsURL(), payload)
+}
+
+func (ne *newrelicExporter) pushTraces(ctx context.Context, td ptrace.Traces) error {
+	payload, err := ne.transformTraces(td)
+	if err != nil {
+		return fmt.Errorf("failed to transform traces: %w", err)
+	}
+
+	return ne.sendToNewRelic(ctx, ne.cfg.GetTracesURL(), payload)
+}
+
+func (ne *newrelicExporter) transformMetrics(md pmetric.Metrics) ([]byte, error) {
+	var metrics []map[string]interface{}
+
+	for i := 0; i < md.ResourceMetrics().Len(); i++ {
+		rm := md.ResourceMetrics().At(i)
+		resourceAttrs := attributesToMap(rm.Resource().Attributes())
+		
+		for j := 0; j < rm.ScopeMetrics().Len(); j++ {
+			sm := rm.ScopeMetrics().At(j)
+			
+			for k := 0; k < sm.Metrics().Len(); k++ {
+				metric := sm.Metrics().At(k)
+				
+				// Convert metric based on type
+				switch metric.Type() {
+				case pmetric.MetricTypeGauge:
+					nrMetrics := ne.convertGauge(metric, resourceAttrs)
+					metrics = append(metrics, nrMetrics...)
+				case pmetric.MetricTypeSum:
+					nrMetrics := ne.convertSum(metric, resourceAttrs)
+					metrics = append(metrics, nrMetrics...)
+				case pmetric.MetricTypeHistogram:
+					nrMetrics := ne.convertHistogram(metric, resourceAttrs)
+					metrics = append(metrics, nrMetrics...)
+				case pmetric.MetricTypeSummary:
+					nrMetrics := ne.convertSummary(metric, resourceAttrs)
+					metrics = append(metrics, nrMetrics...)
+				}
+			}
+		}
+	}
+
+	payload := map[string]interface{}{
+		"metrics": metrics,
+	}
+
+	return json.Marshal(payload)
+}
+
+func (ne *newrelicExporter) convertGauge(metric pmetric.Metric, resourceAttrs map[string]interface{}) []map[string]interface{} {
+	var metrics []map[string]interface{}
+	
+	for i := 0; i < metric.Gauge().DataPoints().Len(); i++ {
+		dp := metric.Gauge().DataPoints().At(i)
+		
+		nrMetric := map[string]interface{}{
+			"name":      metric.Name(),
+			"type":      "gauge",
+			"value":     getDataPointValue(dp),
+			"timestamp": dp.Timestamp().AsTime().Unix(),
+		}
+		
+		// Merge all attributes
+		attrs := ne.mergeAttributes(resourceAttrs, attributesToMap(dp.Attributes()))
+		if len(attrs) > 0 {
+			nrMetric["attributes"] = attrs
+		}
+		
+		metrics = append(metrics, nrMetric)
+	}
+	
+	return metrics
+}
+
+func (ne *newrelicExporter) convertSum(metric pmetric.Metric, resourceAttrs map[string]interface{}) []map[string]interface{} {
+	var metrics []map[string]interface{}
+	
+	for i := 0; i < metric.Sum().DataPoints().Len(); i++ {
+		dp := metric.Sum().DataPoints().At(i)
+		
+		metricType := "count"
+		if metric.Sum().AggregationTemporality() == pmetric.AggregationTemporalityCumulative {
+			metricType = "count"
+		}
+		
+		nrMetric := map[string]interface{}{
+			"name":      metric.Name(),
+			"type":      metricType,
+			"value":     getDataPointValue(dp),
+			"timestamp": dp.Timestamp().AsTime().Unix(),
+		}
+		
+		// Merge all attributes
+		attrs := ne.mergeAttributes(resourceAttrs, attributesToMap(dp.Attributes()))
+		if len(attrs) > 0 {
+			nrMetric["attributes"] = attrs
+		}
+		
+		metrics = append(metrics, nrMetric)
+	}
+	
+	return metrics
+}
+
+func (ne *newrelicExporter) convertHistogram(metric pmetric.Metric, resourceAttrs map[string]interface{}) []map[string]interface{} {
+	var metrics []map[string]interface{}
+	
+	for i := 0; i < metric.Histogram().DataPoints().Len(); i++ {
+		dp := metric.Histogram().DataPoints().At(i)
+		
+		// New Relic histogram format
+		nrMetric := map[string]interface{}{
+			"name":      metric.Name(),
+			"type":      "distribution",
+			"value": map[string]interface{}{
+				"count": dp.Count(),
+				"sum":   dp.Sum(),
+			},
+			"timestamp": dp.Timestamp().AsTime().Unix(),
+		}
+		
+		// Add bucket boundaries and counts if available
+		if dp.BucketCounts().Len() > 0 && dp.ExplicitBounds().Len() > 0 {
+			buckets := make([]map[string]interface{}, 0)
+			bounds := dp.ExplicitBounds()
+			counts := dp.BucketCounts()
+			
+			for j := 0; j < counts.Len(); j++ {
+				bucket := map[string]interface{}{
+					"count": counts.At(j),
+				}
+				
+				if j < bounds.Len() {
+					bucket["upperBound"] = bounds.At(j)
+				}
+				
+				buckets = append(buckets, bucket)
+			}
+			
+			nrMetric["value"].(map[string]interface{})["buckets"] = buckets
+		}
+		
+		// Merge all attributes
+		attrs := ne.mergeAttributes(resourceAttrs, attributesToMap(dp.Attributes()))
+		if len(attrs) > 0 {
+			nrMetric["attributes"] = attrs
+		}
+		
+		metrics = append(metrics, nrMetric)
+	}
+	
+	return metrics
+}
+
+func (ne *newrelicExporter) convertSummary(metric pmetric.Metric, resourceAttrs map[string]interface{}) []map[string]interface{} {
+	var metrics []map[string]interface{}
+	
+	for i := 0; i < metric.Summary().DataPoints().Len(); i++ {
+		dp := metric.Summary().DataPoints().At(i)
+		
+		// New Relic summary format
+		nrMetric := map[string]interface{}{
+			"name":      metric.Name(),
+			"type":      "summary",
+			"value": map[string]interface{}{
+				"count": dp.Count(),
+				"sum":   dp.Sum(),
+			},
+			"timestamp": dp.Timestamp().AsTime().Unix(),
+		}
+		
+		// Add quantile values if available
+		if dp.QuantileValues().Len() > 0 {
+			quantiles := make([]map[string]interface{}, 0)
+			
+			for j := 0; j < dp.QuantileValues().Len(); j++ {
+				qv := dp.QuantileValues().At(j)
+				quantile := map[string]interface{}{
+					"quantile": qv.Quantile(),
+					"value":    qv.Value(),
+				}
+				quantiles = append(quantiles, quantile)
+			}
+			
+			nrMetric["value"].(map[string]interface{})["quantiles"] = quantiles
+		}
+		
+		// Merge all attributes
+		attrs := ne.mergeAttributes(resourceAttrs, attributesToMap(dp.Attributes()))
+		if len(attrs) > 0 {
+			nrMetric["attributes"] = attrs
+		}
+		
+		metrics = append(metrics, nrMetric)
+	}
+	
+	return metrics
+}
+
+func (ne *newrelicExporter) transformLogs(ld plog.Logs) ([]byte, error) {
+	var logs []map[string]interface{}
+
+	for i := 0; i < ld.ResourceLogs().Len(); i++ {
+		rl := ld.ResourceLogs().At(i)
+		resourceAttrs := attributesToMap(rl.Resource().Attributes())
+		
+		for j := 0; j < rl.ScopeLogs().Len(); j++ {
+			sl := rl.ScopeLogs().At(j)
+			
+			for k := 0; k < sl.LogRecords().Len(); k++ {
+				logRecord := sl.LogRecords().At(k)
+				
+				nrLog := map[string]interface{}{
+					"timestamp": logRecord.Timestamp().AsTime().UnixMilli(),
+					"message":   logRecord.Body().AsString(),
+				}
+				
+				// Add severity
+				if logRecord.SeverityText() != "" {
+					nrLog["level"] = logRecord.SeverityText()
+				}
+				
+				// Merge all attributes
+				attrs := ne.mergeAttributes(resourceAttrs, attributesToMap(logRecord.Attributes()))
+				for k, v := range attrs {
+					nrLog[k] = v
+				}
+				
+				logs = append(logs, nrLog)
+			}
+		}
+	}
+
+	payload := map[string]interface{}{
+		"logs": logs,
+	}
+
+	return json.Marshal(payload)
+}
+
+func (ne *newrelicExporter) transformTraces(td ptrace.Traces) ([]byte, error) {
+	var spans []map[string]interface{}
+
+	for i := 0; i < td.ResourceSpans().Len(); i++ {
+		rs := td.ResourceSpans().At(i)
+		resourceAttrs := attributesToMap(rs.Resource().Attributes())
+		
+		for j := 0; j < rs.ScopeSpans().Len(); j++ {
+			ss := rs.ScopeSpans().At(j)
+			
+			for k := 0; k < ss.Spans().Len(); k++ {
+				span := ss.Spans().At(k)
+				
+				nrSpan := map[string]interface{}{
+					"id":        span.SpanID().String(),
+					"trace.id":  span.TraceID().String(),
+					"name":      span.Name(),
+					"timestamp": span.StartTimestamp().AsTime().UnixMilli(),
+					"duration":  span.EndTimestamp().AsTime().Sub(span.StartTimestamp().AsTime()).Milliseconds(),
+				}
+				
+				// Add parent span ID if present
+				if !span.ParentSpanID().IsEmpty() {
+					nrSpan["parent.id"] = span.ParentSpanID().String()
+				}
+				
+				// Add span kind
+				nrSpan["span.kind"] = span.Kind().String()
+				
+				// Merge all attributes
+				attrs := ne.mergeAttributes(resourceAttrs, attributesToMap(span.Attributes()))
+				for k, v := range attrs {
+					nrSpan[k] = v
+				}
+				
+				spans = append(spans, nrSpan)
+			}
+		}
+	}
+
+	payload := map[string]interface{}{
+		"spans": spans,
+	}
+
+	return json.Marshal(payload)
+}
+
+func (ne *newrelicExporter) mergeAttributes(resourceAttrs, dataPointAttrs map[string]interface{}) map[string]interface{} {
+	result := make(map[string]interface{})
+	
+	// Add common attributes first
+	for k, v := range ne.cfg.CommonAttributes {
+		result[k] = v
+	}
+	
+	// Add resource attributes
+	for k, v := range resourceAttrs {
+		result[k] = v
+	}
+	
+	// Add data point attributes (these override resource attributes)
+	for k, v := range dataPointAttrs {
+		result[k] = v
+	}
+	
+	return result
+}
+
+func (ne *newrelicExporter) sendToNewRelic(ctx context.Context, url string, payload []byte) error {
+	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewBuffer(payload))
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Api-Key", ne.cfg.APIKey)
+	req.Header.Set("User-Agent", "run-gmp-sidecar-newrelic-exporter/1.0")
+
+	resp, err := ne.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("New Relic API error: status=%d, body=%s", resp.StatusCode, string(body))
+	}
+
+	ne.logger.Debug("Successfully sent data to New Relic", zap.String("url", url), zap.Int("status", resp.StatusCode))
+	return nil
+}
+
+// Helper functions
+
+func attributesToMap(attrs pcommon.Map) map[string]interface{} {
+	result := make(map[string]interface{})
+	attrs.Range(func(k string, v pcommon.Value) bool {
+		switch v.Type() {
+		case pcommon.ValueTypeStr:
+			result[k] = v.Str()
+		case pcommon.ValueTypeInt:
+			result[k] = v.Int()
+		case pcommon.ValueTypeDouble:
+			result[k] = v.Double()
+		case pcommon.ValueTypeBool:
+			result[k] = v.Bool()
+		default:
+			result[k] = v.AsString()
+		}
+		return true
+	})
+	return result
+}
+
+func getDataPointValue(dp pmetric.NumberDataPoint) interface{} {
+	switch dp.ValueType() {
+	case pmetric.NumberDataPointValueTypeInt:
+		return dp.IntValue()
+	case pmetric.NumberDataPointValueTypeDouble:
+		return dp.DoubleValue()
+	default:
+		return 0
+	}
+}

--- a/collector/exporter/newrelicexporter/factory.go
+++ b/collector/exporter/newrelicexporter/factory.go
@@ -1,0 +1,72 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package newrelicexporter
+
+import (
+	"context"
+	"time"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/config/confighttp"
+	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/exporter"
+	"go.opentelemetry.io/collector/exporter/exporterhelper"
+)
+
+const (
+	// The value of "type" key in configuration.
+	Type = "newrelic"
+	// The stability level of the exporter.
+	stability = component.StabilityLevelBeta
+)
+
+// NewFactory creates a factory for New Relic exporter.
+func NewFactory() exporter.Factory {
+	return exporter.NewFactory(
+		component.MustNewType(Type),
+		createDefaultConfig,
+		exporter.WithMetrics(createMetricsExporter, stability),
+		exporter.WithLogs(createLogsExporter, stability),
+		exporter.WithTraces(createTracesExporter, stability),
+	)
+}
+
+func createDefaultConfig() component.Config {
+	return &Config{
+		ClientConfig: confighttp.ClientConfig{
+			Timeout: 30 * time.Second,
+		},
+		RetrySettings: exporterhelper.NewDefaultRetrySettings(),
+		QueueSettings: exporterhelper.NewDefaultQueueSettings(),
+		TimeoutSettings: exporterhelper.NewDefaultTimeoutSettings(),
+		CommonAttributes: make(map[string]interface{}),
+	}
+}
+
+func createMetricsExporter(
+	ctx context.Context,
+	set exporter.CreateSettings,
+	cfg component.Config,
+) (exporter.Metrics, error) {
+	nrCfg := cfg.(*Config)
+	return newMetricsExporter(nrCfg, set)
+}
+
+func createLogsExporter(
+	ctx context.Context,
+	set exporter.CreateSettings,
+	cfg component.Config,
+) (exporter.Logs, error) {
+	nrCfg := cfg.(*Config)
+	return newLogsExporter(nrCfg, set)
+}
+
+func createTracesExporter(
+	ctx context.Context,
+	set exporter.CreateSettings,
+	cfg component.Config,
+) (exporter.Traces, error) {
+	nrCfg := cfg.(*Config)
+	return newTracesExporter(nrCfg, set)
+}

--- a/collector/service/components.go
+++ b/collector/service/components.go
@@ -38,6 +38,7 @@ import (
 	"go.uber.org/multierr"
 
 	"github.com/GoogleCloudPlatform/run-gmp-sidecar/collector/exporter/googlemanagedprometheusexporter"
+	"github.com/GoogleCloudPlatform/run-gmp-sidecar/collector/exporter/newrelicexporter"
 	"github.com/GoogleCloudPlatform/run-gmp-sidecar/collector/receiver/prometheusreceiver"
 )
 
@@ -72,6 +73,7 @@ func components() (otelcol.Factories, error) {
 		fileexporter.NewFactory(),
 		googlecloudexporter.NewFactory(),
 		googlemanagedprometheusexporter.NewFactory(),
+		newrelicexporter.NewFactory(),
 	}
 	for _, exp := range factories.Exporters {
 		exporters = append(exporters, exp)

--- a/confgenerator/confgenerator.go
+++ b/confgenerator/confgenerator.go
@@ -41,7 +41,7 @@ func (rc *RunMonitoringConfig) GenerateOtelConfig(ctx context.Context, selfMetri
 
 	otelConfig, err := otel.ModularConfig{
 		ReceiverPipelines: receiverPipelines,
-		Exporter:          googleManagedPrometheusExporter(userAgent),
+		Exporter:          newRelicExporter(),
 		SelfMetricsPort:   selfMetricsPort,
 	}.Generate()
 	if err != nil {
@@ -59,6 +59,20 @@ func googleManagedPrometheusExporter(userAgent string) otel.Component {
 			// style suffixes to metric names, e.g., `_total` for a counter; set to false to collect metrics as is
 			"metric": map[string]interface{}{
 				"add_metric_suffixes": false,
+			},
+		},
+	}
+}
+
+func newRelicExporter() otel.Component {
+	return otel.Component{
+		Type: "newrelic",
+		Config: map[string]interface{}{
+			"api_key": "${NEW_RELIC_API_KEY}",
+			"common_attributes": map[string]interface{}{
+				"service.name": "${SERVICE_NAME:-run-gmp-sidecar}",
+				"service.version": "${SERVICE_VERSION:-1.0.0}",
+				"deployment.environment": "${ENVIRONMENT:-production}",
 			},
 		},
 	}

--- a/confgenerator/otel/modular.go
+++ b/confgenerator/otel/modular.go
@@ -86,11 +86,12 @@ func (c ModularConfig) Generate() (string, error) {
 		var processorNames []string
 		processorNames = append(processorNames, receiverProcessorNames...)
 
-		exporters["googlemanagedprometheus"] = c.Exporter.Config
+		exporterName := c.Exporter.Type
+		exporters[exporterName] = c.Exporter.Config
 		pipelines["metrics/"+key] = map[string]interface{}{
 			"receivers":  []string{receiverName},
 			"processors": processorNames,
-			"exporters":  []string{"googlemanagedprometheus"},
+			"exporters":  []string{exporterName},
 		}
 	}
 

--- a/run-service-newrelic-simple.yaml
+++ b/run-service-newrelic-simple.yaml
@@ -1,0 +1,60 @@
+# Simple Cloud Run Service for New Relic (No Volume Mount!)
+# This is the minimal configuration - just your app + sidecar + API key
+
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: my-cloud-run-service-newrelic
+  annotations:
+    run.googleapis.com/execution-environment: gen2
+spec:
+  template:
+    metadata:
+      annotations:
+        run.googleapis.com/cpu-throttling: "false"
+    spec:
+      containerConcurrency: 1000
+      timeoutSeconds: 300
+      containers:
+      # Your application container
+      - name: app
+        image: %SAMPLE_APP_IMAGE%
+        ports:
+        - containerPort: 8080
+        env:
+        - name: PORT
+          value: "8080"
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 512Mi
+            
+      # New Relic sidecar (minimal config!)
+      - name: newrelic-sidecar
+        image: %OTELCOL_IMAGE%
+        env:
+        # Required: New Relic API Key
+        - name: NEW_RELIC_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: newrelic-secrets
+              key: api_key
+        # Optional: Service identification
+        - name: SERVICE_NAME
+          value: "my-cloud-run-service"
+        - name: SERVICE_VERSION  
+          value: "1.0.0"
+        - name: ENVIRONMENT
+          value: "production"
+        resources:
+          limits:
+            cpu: 500m
+            memory: 256Mi
+        # Health check
+        livenessProbe:
+          httpGet:
+            path: /liveness
+            port: 13133
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        # No volume mounts needed! 🎉

--- a/setup-newrelic-simple.sh
+++ b/setup-newrelic-simple.sh
@@ -1,0 +1,117 @@
+#!/bin/bash
+
+# Simple setup script for New Relic deployment (no volume mounts!)
+set -e
+
+# Color output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Configuration
+PROJECT_ID=${GCP_PROJECT:-$(gcloud config get-value project)}
+REGION=${REGION:-us-east1}
+SERVICE_NAME=${SERVICE_NAME:-my-cloud-run-service-newrelic}
+SECRET_NAME=${SECRET_NAME:-newrelic-secrets}
+
+echo -e "${GREEN}🚀 Setting up New Relic integration (simple version - no volumes!)${NC}"
+echo "Project: $PROJECT_ID"
+echo "Region: $REGION"
+echo "Service: $SERVICE_NAME"
+echo ""
+
+# Check required environment variables
+if [ -z "$NEW_RELIC_API_KEY" ]; then
+    echo -e "${RED}❌ Error: NEW_RELIC_API_KEY environment variable is required${NC}"
+    echo "Please set your New Relic Insights Insert API key:"
+    echo "export NEW_RELIC_API_KEY='your-api-key-here'"
+    exit 1
+fi
+
+# Enable required APIs
+echo -e "${YELLOW}📋 Enabling required APIs...${NC}"
+gcloud services enable run.googleapis.com --quiet
+gcloud services enable artifactregistry.googleapis.com --quiet
+gcloud services enable secretmanager.googleapis.com --quiet
+
+# Create New Relic API key secret
+echo -e "${YELLOW}🔐 Creating New Relic API key secret...${NC}"
+if gcloud secrets describe $SECRET_NAME --project=$PROJECT_ID &>/dev/null; then
+    echo "Secret $SECRET_NAME already exists, updating..."
+    echo -n "$NEW_RELIC_API_KEY" | gcloud secrets versions add $SECRET_NAME --data-file=-
+else
+    echo "Creating new secret $SECRET_NAME..."
+    echo -n "$NEW_RELIC_API_KEY" | gcloud secrets create $SECRET_NAME --data-file=-
+fi
+
+# Build and push images
+echo -e "${YELLOW}🔨 Building and pushing images...${NC}"
+
+# Create Artifact Registry repository if it doesn't exist
+if ! gcloud artifacts repositories describe run-gmp --location=$REGION &>/dev/null; then
+    echo "Creating Artifact Registry repository..."
+    gcloud artifacts repositories create run-gmp \
+        --repository-format=docker \
+        --location=$REGION \
+        --project=$PROJECT_ID
+fi
+
+# Authenticate Docker
+gcloud auth configure-docker ${REGION}-docker.pkg.dev
+
+# Build sample app
+echo "Building sample app..."
+pushd sample-apps/simple-app
+docker build -t ${REGION}-docker.pkg.dev/$PROJECT_ID/run-gmp/sample-app .
+docker push ${REGION}-docker.pkg.dev/$PROJECT_ID/run-gmp/sample-app
+popd
+
+# Build New Relic collector
+echo "Building New Relic collector..."
+docker build -f Dockerfile.newrelic -t ${REGION}-docker.pkg.dev/$PROJECT_ID/run-gmp/newrelic-collector .
+docker push ${REGION}-docker.pkg.dev/$PROJECT_ID/run-gmp/newrelic-collector
+
+# Update service configuration (simple version!)
+echo -e "${YELLOW}📝 Updating service configuration...${NC}"
+cp run-service-newrelic-simple.yaml run-service-deploy.yaml
+
+sed -i "s@%SAMPLE_APP_IMAGE%@${REGION}-docker.pkg.dev/${PROJECT_ID}/run-gmp/sample-app@g" run-service-deploy.yaml
+sed -i "s@%OTELCOL_IMAGE%@${REGION}-docker.pkg.dev/${PROJECT_ID}/run-gmp/newrelic-collector@g" run-service-deploy.yaml
+
+# Deploy service
+echo -e "${YELLOW}🚀 Deploying Cloud Run service...${NC}"
+gcloud run services replace run-service-deploy.yaml --region=$REGION
+
+# Make service publicly accessible (optional)
+echo -e "${YELLOW}🌐 Making service publicly accessible...${NC}"
+gcloud run services set-iam-policy $SERVICE_NAME policy.yaml --region=$REGION 2>/dev/null || echo "Warning: Could not set public access policy"
+
+# Get service URL
+SERVICE_URL=$(gcloud run services describe $SERVICE_NAME --region=$REGION --format="value(status.url)")
+
+echo ""
+echo -e "${GREEN}✅ Deployment complete!${NC}"
+echo -e "${GREEN}🔗 Service URL: ${SERVICE_URL}${NC}"
+echo ""
+echo -e "${YELLOW}🧪 Test your deployment:${NC}"
+echo "curl $SERVICE_URL"
+echo ""
+echo -e "${GREEN}📊 Default monitoring config:${NC}"
+echo "  - Scrapes: 0.0.0.0:8080/metrics"
+echo "  - Interval: 30 seconds"
+echo "  - No custom config needed!"
+echo ""
+echo -e "${YELLOW}📊 Check your metrics in New Relic:${NC}"
+echo "- Log into your New Relic account"
+echo "- Navigate to Metrics & Events"
+echo "- Look for metrics from your service"
+echo ""
+echo -e "${YELLOW}🔍 Troubleshooting:${NC}"
+echo "- Check logs: gcloud run services logs tail $SERVICE_NAME --region=$REGION"
+echo "- Verify API key: gcloud secrets versions access latest --secret=$SECRET_NAME"
+
+# Clean up temporary file
+rm -f run-service-deploy.yaml
+
+echo -e "${GREEN}🎉 Setup complete! Super simple - no volumes needed!${NC}"


### PR DESCRIPTION
- Add NewRelic OpenTelemetry exporter
- Simple deployment with no volume mounts required
- Maintains same sidecar architecture as original
- Environment-based configuration via NEW_RELIC_API_KEY