### PR TITLE
[approved, but do not merge] entrypoint: use the intToDouble flag to send target and scope info

### DIFF
--- a/entrypoint.go
+++ b/entrypoint.go
@@ -130,7 +130,7 @@ func main() {
 	var procAttr os.ProcAttr
 	procAttr.Files = []*os.File{nil, /* stdin is not needed for the collector */
 		os.Stdout, os.Stderr}
-	collectorProcess, err := os.StartProcess("./rungmpcol", []string{"./rungmpcol", "--config", otelConfigFile}, &procAttr)
+	collectorProcess, err := os.StartProcess("./rungmpcol", []string{"./rungmpcol", "--feature-gates=exporter.googlemanagedprometheus.intToDouble", "--config", otelConfigFile}, &procAttr)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
This change makes this sidecar consistent with Ops Agent and GBOC.

Change-Id: I1c8219f8fbf440d5122fc25995ddf93536d8e38f