### PR TITLE
Dockerfile: update builder to Go 1.25.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23.0 as builder
+FROM golang:1.25.5 as builder
 WORKDIR /sidecar
 COPY . .
 


### PR DESCRIPTION
This version of Go has a couple of High severity CVEs that we can alleviate by updating to the newest version of Go.