### PR TITLE
Makefile: remove unused ALL_SRC variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,6 @@ OTEL_VERSION = v$(shell $(DISTROGEN_QUERY) opentelemetry_contrib_version)
 # if GOOS is not supplied, set default value based on user's system, will be overridden for OS specific packaging commands
 GOOS ?= $(shell go env GOOS)
 
-ALL_SRC := $(shell find . -name '*.go' -type f | sort)
 ALL_DOC := $(shell find . \( -name "*.md" -o -name "*.yaml" \) -type f | sort)
 GIT_SHA := $(shell git rev-parse --short HEAD)
 


### PR DESCRIPTION
This was inherited by the old version of the
`opentelemetry-operations-collector` repo. It was causing problems because if you build the new distrogen-created sidecar it leaves a ~~`_build` directory with a ton of extra source files~~ a `.tools` directory with a local Go installation and it overloads the Makefile with a ton of Go source files when the variable is evaluated at Makefile load time.

It wasn't used anyway so this PR removes it.