### PR TITLE
Resolving go mod tidy error

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/run-gmp-sidecar
 
-go 1.25.7
+go 1.25.0
 
 toolchain go1.25.7
 


### PR DESCRIPTION
`go` and `toolchain` are not allowed to be the same; try the major version for `go` for now.